### PR TITLE
chore: update version to 0.1.0-preview in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pict-mcp",
-  "version": "0.1.0",
+  "version": "0.1.0-preview",
   "type": "module",
   "description": "Pairwise Independent Combinatorial Testings for MCP",
   "bin": {


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The change updates the version from `0.1.0` to `0.1.0-preview` to indicate a preview release.