### PR TITLE
docs: update README.md to include missing command and remove license sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ In your terminal
 
 ```sh
 git clone https://github.com/takeyaqa/pict-mcp.git
+cd pict-mcp
 pnpm install
 pnpm build
 ```
@@ -41,38 +42,3 @@ In your MCP client
   }
 }
 ```
-
-
-## Microsoft PICT License
-
-pict-mcp includes and distributes [Microsoft PICT (Pairwise Independent Combinatorial Testing)](https://github.com/microsoft/pict), which is licensed under the MIT License:
-
-```
-MIT License
-
-Copyright (c) Microsoft Corporation. All rights reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-```
-
-## pict-mcp License
-
-pict-mcp is licensed under the MIT License:
-
-[LICENSE](LICENSE)


### PR DESCRIPTION
This pull request updates the `README.md` file to improve clarity and remove redundant information. The changes include adding a missing step in the project setup instructions and removing licensing details that are already covered elsewhere.

### Documentation Improvements:

* Added a missing `cd pict-mcp` step to the project setup instructions under the "In your terminal" section to ensure users navigate to the correct directory before running commands. (`README.md`, [README.mdR26](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R26))

### Cleanup:

* Removed the "Microsoft PICT License" and "pict-mcp License" sections from the README, as this information is either redundant or better suited for a dedicated `LICENSE` file. (`README.md`, [README.mdL44-L78](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L44-L78))